### PR TITLE
recover transform-strip-jsnext

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,8 @@
 {
   "env": {
     "build": {
-      "presets": ["env", "flow"]
+      "presets": ["env", "flow"],
+      "plugins": ["transform-strip-jsnext"]
     },
 
     "development": {


### PR DESCRIPTION
Env plugins in .babelrc was removed by accident the commit below.
https://github.com/shinout/phenyl/commit/f36815e2183118c4e1d44f3c995f7a7138f6109e#diff-e56633f72ecc521128b3db6586074d2cL3