### PR TITLE
Fix Cannot find module 'phenyl-api-explorer'

### DIFF
--- a/modules/phenyl-api-explorer/package.json
+++ b/modules/phenyl-api-explorer/package.json
@@ -2,7 +2,7 @@
   "name": "phenyl-api-explorer",
   "version": "0.1.0",
   "description": "Automatically renders API explorer pages like swagger",
-  "main": "./dist/index.js",
+  "main": "./dist/PhenylApiExplorer.js",
   "jsnext:main": "./jsnext.js",
   "scripts": {
     "start": "nodemon examples/index.js --exec babel-node --watch src --watch examples",


### PR DESCRIPTION
`phenyl-api-explorer` exists but require failed.

```
$ node
> require('phenyl-api-explorer')
Error: Cannot find module 'phenyl-api-explorer'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
```

```
$ ls node_modules/phenyl-api-explorer
dist		examples	package.json	src
```

Fix main field path