### PR TITLE
fix: add content-type to encoded push request

### DIFF
--- a/modules/http-rules/src/encode-request.ts
+++ b/modules/http-rules/src/encode-request.ts
@@ -1,7 +1,7 @@
 import {
   EncodedHttpRequest,
   GeneralRequestData,
-  QueryStringParams
+  QueryStringParams,
 } from "@phenyl/interfaces";
 
 import { assertValidRequestData } from "@phenyl/utils";
@@ -17,7 +17,7 @@ export default function encodeRequest(
   const headers: { [name: string]: string } =
     sessionId != null
       ? {
-          authorization: sessionId
+          authorization: sessionId,
         }
       : {};
   let data;
@@ -29,7 +29,7 @@ export default function encodeRequest(
         method: "GET",
         headers,
         path: addPrefix(`/${data.entityName}/find`),
-        qsParams: createQsParams(data)
+        qsParams: createQsParams(data),
       };
 
     case "findOne":
@@ -38,7 +38,7 @@ export default function encodeRequest(
         method: "GET",
         headers,
         path: addPrefix(`/${data.entityName}/findOne`),
-        qsParams: createQsParams(data)
+        qsParams: createQsParams(data),
       };
 
     case "get":
@@ -46,7 +46,7 @@ export default function encodeRequest(
       return {
         method: "GET",
         headers,
-        path: addPrefix(`/${data.entityName}/${data.id}`)
+        path: addPrefix(`/${data.entityName}/${data.id}`),
       };
 
     case "getByIds":
@@ -55,7 +55,7 @@ export default function encodeRequest(
         method: "GET",
         headers,
         path: addPrefix(`/${data.entityName}/getByIds`),
-        qsParams: createQsParams(data)
+        qsParams: createQsParams(data),
       };
 
     case "pull":
@@ -64,7 +64,7 @@ export default function encodeRequest(
         method: "GET",
         headers,
         path: addPrefix(`/${data.entityName}/pull`),
-        qsParams: createQsParams(data)
+        qsParams: createQsParams(data),
       };
 
     case "insertOne":
@@ -75,7 +75,7 @@ export default function encodeRequest(
         method: "POST",
         headers,
         path: addPrefix(`/${data.entityName}/${reqData.method}`),
-        body: createBody(data)
+        body: createBody(data),
       };
 
     case "insertAndGet":
@@ -85,7 +85,7 @@ export default function encodeRequest(
         method: "POST",
         headers,
         path: addPrefix(`/${data.entityName}/insertAndGet`),
-        body: createBody(data)
+        body: createBody(data),
       };
 
     case "insertAndGetMulti":
@@ -95,7 +95,7 @@ export default function encodeRequest(
         method: "POST",
         headers,
         path: addPrefix(`/${data.entityName}/insertAndGetMulti`),
-        body: createBody(data)
+        body: createBody(data),
       };
 
     case "updateById":
@@ -105,7 +105,7 @@ export default function encodeRequest(
         method: "PUT",
         headers,
         path: addPrefix(`/${data.entityName}/updateById`),
-        body: createBody(data)
+        body: createBody(data),
       };
 
     case "updateMulti":
@@ -115,7 +115,7 @@ export default function encodeRequest(
         method: "PUT",
         headers,
         path: addPrefix(`/${data.entityName}/updateMulti`),
-        body: createBody(data)
+        body: createBody(data),
       };
 
     case "updateAndGet":
@@ -125,7 +125,7 @@ export default function encodeRequest(
         method: "PUT",
         headers,
         path: addPrefix(`/${data.entityName}/updateAndGet`),
-        body: createBody(data)
+        body: createBody(data),
       };
 
     case "updateAndFetch":
@@ -135,16 +135,17 @@ export default function encodeRequest(
         method: "PUT",
         headers,
         path: addPrefix(`/${data.entityName}/updateAndFetch`),
-        body: createBody(data)
+        body: createBody(data),
       };
 
     case "push":
       data = reqData.payload;
+      headers["Content-Type"] = "application/json";
       return {
         method: "PUT",
         headers,
         path: addPrefix(`/${data.entityName}/push`),
-        body: createBody(data)
+        body: createBody(data),
       };
 
     case "delete":
@@ -155,7 +156,7 @@ export default function encodeRequest(
         return {
           method: "DELETE",
           headers,
-          path: addPrefix(`/${data.entityName}/${(<{ id: string }>data).id}`)
+          path: addPrefix(`/${data.entityName}/${(<{ id: string }>data).id}`),
         };
       } // multi deletion
 
@@ -163,7 +164,7 @@ export default function encodeRequest(
         method: "DELETE",
         headers,
         path: addPrefix(`/${data.entityName}/delete`),
-        qsParams: createQsParams(data)
+        qsParams: createQsParams(data),
       };
 
     case "runCustomQuery":
@@ -172,7 +173,7 @@ export default function encodeRequest(
         method: "GET",
         headers,
         path: addPrefix(`/${data.name}`),
-        qsParams: createQsParams(data)
+        qsParams: createQsParams(data),
       };
 
     case "runCustomCommand":
@@ -182,7 +183,7 @@ export default function encodeRequest(
         method: "POST",
         headers,
         path: addPrefix(`/${data.name}`),
-        body: createBody(data)
+        body: createBody(data),
       };
 
     case "login":
@@ -192,7 +193,7 @@ export default function encodeRequest(
         method: "POST",
         headers,
         path: addPrefix(`/${data.entityName}/login`),
-        body: createBody(data)
+        body: createBody(data),
       };
 
     case "logout":
@@ -202,7 +203,7 @@ export default function encodeRequest(
         method: "POST",
         headers,
         path: addPrefix(`/${data.entityName}/logout`),
-        body: createBody(data)
+        body: createBody(data),
       };
 
     default:
@@ -224,7 +225,7 @@ function undefinedToNull(key: string, value: any): any {
 
 function createQsParams(data: Object): QueryStringParams {
   return {
-    d: JSON.stringify(data, undefinedToNull)
+    d: JSON.stringify(data, undefinedToNull),
   };
 }
 

--- a/modules/http-rules/test/encode-decode-request.test.ts
+++ b/modules/http-rules/test/encode-decode-request.test.ts
@@ -80,7 +80,7 @@ describe("Check encode/decode deep equality: ", () => {
     assert.deepStrictEqual(decodedReqData, reqData);
     assert(decodedReqData.sessionId === "foobar");
   });
-  it("insertOne", () => {
+  describe("insertOne", () => {
     const reqData: GeneralRequestData = {
       method: "insertOne",
       payload: {
@@ -94,10 +94,16 @@ describe("Check encode/decode deep equality: ", () => {
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
-    assert.deepStrictEqual(decodedReqData, reqData);
-    assert(decodedReqData.sessionId === "foobar");
+    it("has content-type in header", () => {
+      assert(encodedHttpRequest.headers["Content-Type"] === "application/json");
+    });
+
+    it("returns same request", () => {
+      assert.deepStrictEqual(decodedReqData, reqData);
+      assert(decodedReqData.sessionId === "foobar");
+    });
   });
-  it("insertMulti", () => {
+  describe("insertMulti", () => {
     const reqData: GeneralRequestData = {
       method: "insertMulti",
       payload: {
@@ -113,10 +119,16 @@ describe("Check encode/decode deep equality: ", () => {
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
-    assert.deepStrictEqual(decodedReqData, reqData);
-    assert(decodedReqData.sessionId === "foobar");
+    it("has content-type in header", () => {
+      assert(encodedHttpRequest.headers["Content-Type"] === "application/json");
+    });
+
+    it("returns same request", () => {
+      assert.deepStrictEqual(decodedReqData, reqData);
+      assert(decodedReqData.sessionId === "foobar");
+    });
   });
-  it("insertAndGet", () => {
+  describe("insertAndGet", () => {
     const reqData: GeneralRequestData = {
       method: "insertAndGet",
       payload: {
@@ -130,10 +142,16 @@ describe("Check encode/decode deep equality: ", () => {
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
-    assert.deepStrictEqual(decodedReqData, reqData);
-    assert(decodedReqData.sessionId === "foobar");
+    it("has content-type in header", () => {
+      assert(encodedHttpRequest.headers["Content-Type"] === "application/json");
+    });
+
+    it("returns same request", () => {
+      assert.deepStrictEqual(decodedReqData, reqData);
+      assert(decodedReqData.sessionId === "foobar");
+    });
   });
-  it("insertAndGetMulti", () => {
+  describe("insertAndGetMulti", () => {
     const reqData: GeneralRequestData = {
       method: "insertAndGetMulti",
       payload: {
@@ -153,10 +171,16 @@ describe("Check encode/decode deep equality: ", () => {
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
-    assert.deepStrictEqual(decodedReqData, reqData);
-    assert(decodedReqData.sessionId === "foobar");
+    it("has content-type in header", () => {
+      assert(encodedHttpRequest.headers["Content-Type"] === "application/json");
+    });
+
+    it("returns same request", () => {
+      assert.deepStrictEqual(decodedReqData, reqData);
+      assert(decodedReqData.sessionId === "foobar");
+    });
   });
-  it("updateById", () => {
+  describe("updateById", () => {
     const reqData: GeneralRequestData = {
       method: "updateById",
       payload: {
@@ -172,10 +196,16 @@ describe("Check encode/decode deep equality: ", () => {
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
-    assert.deepStrictEqual(decodedReqData, reqData);
-    assert(decodedReqData.sessionId === "foobar");
+    it("has content-type in header", () => {
+      assert(encodedHttpRequest.headers["Content-Type"] === "application/json");
+    });
+
+    it("returns same request", () => {
+      assert.deepStrictEqual(decodedReqData, reqData);
+      assert(decodedReqData.sessionId === "foobar");
+    });
   });
-  it("updateMulti", () => {
+  describe("updateMulti", () => {
     const reqData: GeneralRequestData = {
       method: "updateMulti",
       payload: {
@@ -193,10 +223,16 @@ describe("Check encode/decode deep equality: ", () => {
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
-    assert.deepStrictEqual(decodedReqData, reqData);
-    assert(decodedReqData.sessionId === "foobar");
+    it("has content-type in header", () => {
+      assert(encodedHttpRequest.headers["Content-Type"] === "application/json");
+    });
+
+    it("returns same request", () => {
+      assert.deepStrictEqual(decodedReqData, reqData);
+      assert(decodedReqData.sessionId === "foobar");
+    });
   });
-  it("updateAndGet", () => {
+  describe("updateAndGet", () => {
     const reqData: GeneralRequestData = {
       method: "updateAndGet",
       payload: {
@@ -212,10 +248,16 @@ describe("Check encode/decode deep equality: ", () => {
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
-    assert.deepStrictEqual(decodedReqData, reqData);
-    assert(decodedReqData.sessionId === "foobar");
+    it("has content-type in header", () => {
+      assert(encodedHttpRequest.headers["Content-Type"] === "application/json");
+    });
+
+    it("returns same request", () => {
+      assert.deepStrictEqual(decodedReqData, reqData);
+      assert(decodedReqData.sessionId === "foobar");
+    });
   });
-  it("updateAndFetch", () => {
+  describe("updateAndFetch", () => {
     const reqData: GeneralRequestData = {
       method: "updateAndFetch",
       payload: {
@@ -233,10 +275,16 @@ describe("Check encode/decode deep equality: ", () => {
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
-    assert.deepStrictEqual(decodedReqData, reqData);
-    assert(decodedReqData.sessionId === "foobar");
+    it("has content-type in header", () => {
+      assert(encodedHttpRequest.headers["Content-Type"] === "application/json");
+    });
+
+    it("returns same request", () => {
+      assert.deepStrictEqual(decodedReqData, reqData);
+      assert(decodedReqData.sessionId === "foobar");
+    });
   });
-  it("push", () => {
+  describe("push", () => {
     const reqData: GeneralRequestData = {
       method: "push",
       payload: {
@@ -254,12 +302,16 @@ describe("Check encode/decode deep equality: ", () => {
       sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
-
-    assert(encodedHttpRequest.headers["Content-Type"] === "application/json");
-
     const decodedReqData = decodeRequest(encodedHttpRequest);
-    assert.deepStrictEqual(decodedReqData, reqData);
-    assert(decodedReqData.sessionId === "foobar");
+
+    it("has content-type in header", () => {
+      assert(encodedHttpRequest.headers["Content-Type"] === "application/json");
+    });
+
+    it("returns same request", () => {
+      assert.deepStrictEqual(decodedReqData, reqData);
+      assert(decodedReqData.sessionId === "foobar");
+    });
   });
   it("delete", () => {
     const reqData: GeneralRequestData = {
@@ -305,7 +357,7 @@ describe("Check encode/decode deep equality: ", () => {
     const decodedReqData = decodeRequest(encodedHttpRequest);
     assert.deepStrictEqual(reqData, decodedReqData);
   });
-  it("runCustomCommand", () => {
+  describe("runCustomCommand", () => {
     const reqData: GeneralRequestData = {
       method: "runCustomCommand",
       payload: {
@@ -318,8 +370,14 @@ describe("Check encode/decode deep equality: ", () => {
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
-    assert.deepStrictEqual(decodedReqData, reqData);
-    assert(decodedReqData.sessionId === "foobar");
+    it("has content-type in header", () => {
+      assert(encodedHttpRequest.headers["Content-Type"] === "application/json");
+    });
+
+    it("returns same request", () => {
+      assert.deepStrictEqual(decodedReqData, reqData);
+      assert(decodedReqData.sessionId === "foobar");
+    });
   });
   it("login", () => {
     const reqData: GeneralRequestData = {

--- a/modules/http-rules/test/encode-decode-request.test.ts
+++ b/modules/http-rules/test/encode-decode-request.test.ts
@@ -11,10 +11,10 @@ describe("Check encode/decode deep equality: ", () => {
       payload: {
         entityName: "hospital",
         where: {
-          name: "Tokyo Hospital"
-        }
+          name: "Tokyo Hospital",
+        },
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -27,10 +27,10 @@ describe("Check encode/decode deep equality: ", () => {
       payload: {
         entityName: "hospital",
         where: {
-          name: "Tokyo Hospital"
-        }
+          name: "Tokyo Hospital",
+        },
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -42,9 +42,9 @@ describe("Check encode/decode deep equality: ", () => {
       method: "get",
       payload: {
         entityName: "hospital",
-        id: "tokyo"
+        id: "tokyo",
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -56,9 +56,9 @@ describe("Check encode/decode deep equality: ", () => {
       method: "getByIds",
       payload: {
         entityName: "hospital",
-        ids: ["tokyo", "nagoya", "osaka"]
+        ids: ["tokyo", "nagoya", "osaka"],
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -71,9 +71,9 @@ describe("Check encode/decode deep equality: ", () => {
       payload: {
         entityName: "hospital",
         id: "foo",
-        versionId: "abc123"
+        versionId: "abc123",
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -87,10 +87,10 @@ describe("Check encode/decode deep equality: ", () => {
         entityName: "hospital",
         value: {
           name: "Tokyo Hospital",
-          address: "dummy-dummy"
-        }
+          address: "dummy-dummy",
+        },
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -105,11 +105,11 @@ describe("Check encode/decode deep equality: ", () => {
         values: [
           {
             name: "Tokyo Hospital",
-            address: "dummy-dummy"
-          }
-        ]
+            address: "dummy-dummy",
+          },
+        ],
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -123,10 +123,10 @@ describe("Check encode/decode deep equality: ", () => {
         entityName: "hospital",
         value: {
           name: "Tokyo Hospital",
-          address: "dummy-dummy"
-        }
+          address: "dummy-dummy",
+        },
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -141,15 +141,15 @@ describe("Check encode/decode deep equality: ", () => {
         values: [
           {
             name: "Tokyo Hospital",
-            address: "dummy-dummy"
+            address: "dummy-dummy",
           },
           {
             name: "Nagoya Hospital",
-            address: "dummy-dummy-dummy"
-          }
-        ]
+            address: "dummy-dummy-dummy",
+          },
+        ],
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -164,11 +164,11 @@ describe("Check encode/decode deep equality: ", () => {
         entityName: "hospital",
         operation: {
           $set: {
-            tel: "dummy"
-          }
-        }
+            tel: "dummy",
+          },
+        },
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -180,16 +180,16 @@ describe("Check encode/decode deep equality: ", () => {
       method: "updateMulti",
       payload: {
         where: {
-          id: "tokyo"
+          id: "tokyo",
         },
         entityName: "hospital",
         operation: {
           $set: {
-            tel: "dummy"
-          }
-        }
+            tel: "dummy",
+          },
+        },
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -204,11 +204,11 @@ describe("Check encode/decode deep equality: ", () => {
         entityName: "hospital",
         operation: {
           $set: {
-            tel: "dummy"
-          }
-        }
+            tel: "dummy",
+          },
+        },
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -221,15 +221,15 @@ describe("Check encode/decode deep equality: ", () => {
       payload: {
         entityName: "hospital",
         where: {
-          name: "tokyo"
+          name: "tokyo",
         },
         operation: {
           $set: {
-            tel: "dummy"
-          }
-        }
+            tel: "dummy",
+          },
+        },
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -246,14 +246,17 @@ describe("Check encode/decode deep equality: ", () => {
         operations: [
           {
             $set: {
-              tel: "dummy"
-            }
-          }
-        ]
+              tel: "dummy",
+            },
+          },
+        ],
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
+
+    assert(encodedHttpRequest.headers["Content-Type"] === "application/json");
+
     const decodedReqData = decodeRequest(encodedHttpRequest);
     assert.deepStrictEqual(decodedReqData, reqData);
     assert(decodedReqData.sessionId === "foobar");
@@ -264,10 +267,10 @@ describe("Check encode/decode deep equality: ", () => {
       payload: {
         entityName: "hospital",
         where: {
-          name: "tokyo"
-        }
+          name: "tokyo",
+        },
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -280,10 +283,10 @@ describe("Check encode/decode deep equality: ", () => {
       payload: {
         name: "is-occupied",
         params: {
-          email: "abc@example.com"
-        }
+          email: "abc@example.com",
+        },
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -295,8 +298,8 @@ describe("Check encode/decode deep equality: ", () => {
       method: "runCustomQuery",
       payload: {
         name: "is-occupied",
-        params: {}
-      }
+        params: {},
+      },
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -308,10 +311,10 @@ describe("Check encode/decode deep equality: ", () => {
       payload: {
         name: "reset-password",
         params: {
-          email: "abc@example.com"
-        }
+          email: "abc@example.com",
+        },
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -325,10 +328,10 @@ describe("Check encode/decode deep equality: ", () => {
         entityName: "doctor",
         credentials: {
           email: "abc@example.com",
-          password: "dummy"
-        }
+          password: "dummy",
+        },
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);
@@ -341,9 +344,9 @@ describe("Check encode/decode deep equality: ", () => {
       payload: {
         entityName: "doctor",
         sessionId: "foobar",
-        userId: "shinout"
+        userId: "shinout",
       },
-      sessionId: "foobar"
+      sessionId: "foobar",
     };
     const encodedHttpRequest = encodeRequest(reqData);
     const decodedReqData = decodeRequest(encodedHttpRequest);


### PR DESCRIPTION
encoded Push request did not include any `content-type` in its request header, whereas other request that performs PUSH method has a content-type.
This PR adds content-type to push request for consistency