### PR TITLE
fix: clear unreached commits when commits are pushed successfully

### DIFF
--- a/modules/redux/package.json
+++ b/modules/redux/package.json
@@ -20,7 +20,9 @@
   "scripts": {
     "build": "upbin tsc -p tsconfig.build.json",
     "clean": "rm -rf lib",
-    "test": "upbin nyc upbin mocha --require ts-node/register 'test/**/*.test.ts' --color always",
+    "test": "npm run test:spec && npm run test:integration",
+    "test:spec": "upbin nyc upbin mocha --require ts-node/register 'test/spec/**/*.test.ts' --color always",
+    "test:integration": "upbin nyc upbin mocha --require ts-node/register 'test/integration/**/*.test.ts' --color always",
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
@@ -35,7 +37,9 @@
     "@phenyl/memory-db": "^4.0.1",
     "@phenyl/rest-api": "^4.0.1",
     "@phenyl/standards": "^4.0.1",
+    "@types/sinon": "^9.0.10",
     "redux": "4.0.5",
+    "sinon": "^9.2.4",
     "upbin": "0.9.2"
   },
   "publishConfig": {

--- a/modules/redux/src/local-state-updater.ts
+++ b/modules/redux/src/local-state-updater.ts
@@ -14,7 +14,7 @@ import {
   GeneralLocalState,
   PushCommandOf,
   ResponseEntityOf,
-  UserEntityNameOf
+  UserEntityNameOf,
 } from "@phenyl/interfaces";
 import { LocalStateFinder } from "./local-state-finder";
 
@@ -37,8 +37,8 @@ export class LocalStateUpdater {
   ): GeneralUpdateOperation {
     return {
       $set: {
-        [createDocumentPath("entities", entityName)]: {}
-      }
+        [createDocumentPath("entities", entityName)]: {},
+      },
     };
   }
   /**
@@ -55,7 +55,7 @@ export class LocalStateUpdater {
     if (
       !LocalStateFinder.hasEntity(state, {
         entityName,
-        id
+        id,
       })
     ) {
       throw new Error(
@@ -65,16 +65,16 @@ export class LocalStateUpdater {
 
     const entity = LocalStateFinder.getHeadEntity(state, {
       id,
-      entityName
+      entityName,
     });
     const newEntity = update(entity, operation);
     return {
       $push: {
-        [createDocumentPath("entities", entityName, id, "commits")]: operation
+        [createDocumentPath("entities", entityName, id, "commits")]: operation,
       },
       $set: {
-        [createDocumentPath("entities", entityName, id, "head")]: newEntity
-      }
+        [createDocumentPath("entities", entityName, id, "head")]: newEntity,
+      },
     };
   }
 
@@ -91,7 +91,7 @@ export class LocalStateUpdater {
     if (
       !LocalStateFinder.hasEntity(state, {
         entityName,
-        id
+        id,
       })
     ) {
       throw new Error(
@@ -101,7 +101,7 @@ export class LocalStateUpdater {
 
     const entityInfo = LocalStateFinder.getEntityInfo(state, {
       id,
-      entityName
+      entityName,
     });
     const commits = operations.reduce(
       (restCommits, op) => removeOne(restCommits, op),
@@ -111,8 +111,8 @@ export class LocalStateUpdater {
     return {
       $set: {
         [createDocumentPath("entities", entityName, id, "commits")]: commits,
-        [createDocumentPath("entities", entityName, id, "head")]: restoredHead
-      }
+        [createDocumentPath("entities", entityName, id, "head")]: restoredHead,
+      },
     };
   }
 
@@ -132,9 +132,9 @@ export class LocalStateUpdater {
           origin: entity,
           versionId,
           commits: [],
-          head: null
-        }
-      }
+          head: null,
+        },
+      },
     };
   }
 
@@ -148,8 +148,8 @@ export class LocalStateUpdater {
   ): GeneralUpdateOperation {
     return {
       $unset: {
-        [createDocumentPath("entities", entityName, id)]: ""
-      }
+        [createDocumentPath("entities", entityName, id)]: "",
+      },
     };
   }
 
@@ -165,7 +165,7 @@ export class LocalStateUpdater {
   ): GeneralUpdateOperation {
     const { entityName, id, commitCount } = commit;
     const enqueuedCount = state.unreachedCommits
-      .filter(c => c.entityName === entityName && c.id === id)
+      .filter((c) => c.entityName === entityName && c.id === id)
       .reduce((acc, c) => acc + c.commitCount, 0);
 
     if (commitCount <= enqueuedCount) {
@@ -177,9 +177,9 @@ export class LocalStateUpdater {
         [createDocumentPath("unreachedCommits")]: {
           entityName,
           id,
-          commitCount: commitCount - enqueuedCount
-        }
-      }
+          commitCount: commitCount - enqueuedCount,
+        },
+      },
     };
   }
 
@@ -196,9 +196,30 @@ export class LocalStateUpdater {
     return {
       $pull: {
         [createDocumentPath("unreachedCommits")]: {
-          $in: [commit]
-        }
-      }
+          $in: [commit],
+        },
+      },
+    };
+  }
+
+  /**
+   * clear unreached commits by entityName and entityId
+   */
+  static clearUnreachedCommitsByEntityInfo<
+    TM extends GeneralTypeMap,
+    EN extends EntityNameOf<TM>
+  >(
+    state: LocalStateOf<TM>,
+    entityName: string,
+    id: string
+  ): GeneralUpdateOperation {
+    return {
+      $pull: {
+        [createDocumentPath("unreachedCommits")]: {
+          entityName,
+          id,
+        },
+      },
     };
   }
 
@@ -211,8 +232,8 @@ export class LocalStateUpdater {
   ): GeneralUpdateOperation {
     return {
       $push: {
-        [createDocumentPath("network", "requests")]: tag
-      }
+        [createDocumentPath("network", "requests")]: tag,
+      },
     };
   }
 
@@ -228,8 +249,8 @@ export class LocalStateUpdater {
         [createDocumentPath("network", "requests")]: removeOne(
           state.network.requests,
           tag
-        )
-      }
+        ),
+      },
     };
   }
 
@@ -245,7 +266,7 @@ export class LocalStateUpdater {
     const { entityName, id, versionId, prevVersionId } = versionDiff;
     const entityInfo = LocalStateFinder.getEntityInfo(state, {
       id,
-      entityName
+      entityName,
     }); // Not applicable diff.
 
     if (entityInfo.versionId !== prevVersionId) {
@@ -263,8 +284,8 @@ export class LocalStateUpdater {
           id,
           "versionId"
         )]: versionId,
-        [createDocumentPath("entities", entityName, id, "head")]: newHead
-      }
+        [createDocumentPath("entities", entityName, id, "head")]: newHead,
+      },
     };
   }
 
@@ -279,7 +300,7 @@ export class LocalStateUpdater {
     const { entityName, id, versionId, operations } = pushCommand;
     const entityInfo = LocalStateFinder.getEntityInfo(state, {
       id,
-      entityName
+      entityName,
     });
     const newOrigin = update(entityInfo.origin, ...operations);
     const newHead =
@@ -295,8 +316,8 @@ export class LocalStateUpdater {
           id,
           "versionId"
         )]: versionId,
-        [createDocumentPath("entities", entityName, id, "head")]: newHead
-      }
+        [createDocumentPath("entities", entityName, id, "head")]: newHead,
+      },
     };
   }
 
@@ -311,7 +332,7 @@ export class LocalStateUpdater {
     const { entityName, id, operations, versionId } = pushCommand;
     const entityInfo = LocalStateFinder.getEntityInfo(state, {
       id,
-      entityName
+      entityName,
     });
     const newOrigin = update(entityInfo.origin, ...operations, ...localCommits); // assert(localCommits.length === 0 || entityInfo.commits[0] === localCommits[0])
 
@@ -324,9 +345,9 @@ export class LocalStateUpdater {
           origin: newOrigin,
           versionId,
           commits: newCommits,
-          head: newHead
-        }
-      }
+          head: newHead,
+        },
+      },
     };
   }
 
@@ -351,7 +372,7 @@ export class LocalStateUpdater {
     }
 
     return {
-      $set: $setOp
+      $set: $setOp,
     };
   }
 
@@ -367,8 +388,8 @@ export class LocalStateUpdater {
     const { entityName } = session;
     const operation = {
       $set: {
-        session
-      }
+        session,
+      },
     };
 
     if (user != null && versionId != null) {
@@ -385,8 +406,8 @@ export class LocalStateUpdater {
   static unsetSession(): GeneralUpdateOperation {
     return {
       $unset: {
-        session: ""
-      }
+        session: "",
+      },
     };
   }
 
@@ -404,9 +425,9 @@ export class LocalStateUpdater {
           type: err.type,
           at: err.at,
           message: err.message,
-          actionTag
-        }
-      }
+          actionTag,
+        },
+      },
     };
   }
 
@@ -416,8 +437,8 @@ export class LocalStateUpdater {
   static online(): GeneralUpdateOperation {
     return {
       $set: {
-        [createDocumentPath("network", "isOnline")]: true
-      }
+        [createDocumentPath("network", "isOnline")]: true,
+      },
     };
   }
 
@@ -427,8 +448,8 @@ export class LocalStateUpdater {
   static offline(): GeneralUpdateOperation {
     return {
       $set: {
-        [createDocumentPath("network", "isOnline")]: false
-      }
+        [createDocumentPath("network", "isOnline")]: false,
+      },
     };
   }
 
@@ -438,8 +459,8 @@ export class LocalStateUpdater {
   static resolveError(): GeneralUpdateOperation {
     return {
       $unset: {
-        [createDocumentPath("error")]: ""
-      }
+        [createDocumentPath("error")]: "",
+      },
     };
   }
 }

--- a/modules/redux/src/middleware.ts
+++ b/modules/redux/src/middleware.ts
@@ -185,6 +185,7 @@ export class MiddlewareHandler<TM extends GeneralTypeMap> {
 
   /**
    * Commit to LocalState and then Push to the CentralState.
+   * If succeeded, unreached commits for entity are cleared
    * If failed, the commit is still applied.
    * In such cases, pull the entity first.
    * Only when Authorization Error occurred, it will be rollbacked.
@@ -212,6 +213,15 @@ export class MiddlewareHandler<TM extends GeneralTypeMap> {
 
     try {
       const result = await this.client.push(pushCommand, this.sessionId);
+
+      // Check if entityId exists in unreached commits, and filter those commits as they are pushed successfully
+      ops.push(
+        LocalStateUpdater.clearUnreachedCommitsByEntityInfo(
+          this.state,
+          entityName,
+          id
+        )
+      );
 
       if (result.hasEntity) {
         ops.push(
@@ -523,6 +533,7 @@ export class MiddlewareHandler<TM extends GeneralTypeMap> {
 
   /**
    * Push to the CentralState, then commit to LocalState.
+   * If succeeded, unreached commits for entity are cleared
    * If push failed, the commit is not applied.
    */
   async pushAndCommit<EN extends EntityNameOf<TM>>(
@@ -550,6 +561,14 @@ export class MiddlewareHandler<TM extends GeneralTypeMap> {
 
     try {
       const result = await this.client.push(pushCommand, this.sessionId);
+      // Check if entityId exists in unreached commits, and filter those commits as they are pushed successfully
+      ops.push(
+        LocalStateUpdater.clearUnreachedCommitsByEntityInfo(
+          this.state,
+          entityName,
+          id
+        )
+      );
 
       if (result.hasEntity) {
         ops.push(

--- a/modules/redux/test/helper.ts
+++ b/modules/redux/test/helper.ts
@@ -1,0 +1,119 @@
+import http from "http";
+import { createStore, combineReducers, applyMiddleware } from "redux";
+import PhenylHttpServer from "@phenyl/http-server";
+import PhenylRestApi from "@phenyl/rest-api";
+import PhenylHttpClient from "@phenyl/http-client";
+import {
+  GeneralTypeMap,
+  GeneralAction,
+  LocalState,
+  AuthCommandMapOf,
+  ResponseEntityMapOf,
+} from "../../interfaces";
+import { createEntityClient as createMemoryClient } from "@phenyl/memory-db";
+import { StandardUserDefinition } from "@phenyl/standards";
+import { createRedux } from "../src";
+
+export const PORT = 8080;
+const HTTP_CLIENT_URL = `http://localhost`;
+
+type PlainPatient = {
+  id: string;
+  name: string;
+  email: string;
+  password: string;
+};
+
+export type PatientResponse = PlainPatient;
+export type PatientRequest = PlainPatient;
+
+type MyEntityRestInfoMap = {
+  patient: {
+    request: PatientRequest;
+    response: PatientResponse;
+  };
+};
+
+type Store = {
+  phenyl: LocalState<MyEntityRestInfoMap, AuthCommandMapOf<MyTypeMap>>;
+};
+
+interface MyTypeMap extends GeneralTypeMap {
+  entities: MyEntityRestInfoMap;
+  customQueries: {};
+  customCommands: {};
+  auths: {
+    patient: {
+      credentials: {
+        email: string;
+        password: string;
+      };
+      session: { externalId: string; ttl: number };
+    };
+  };
+}
+
+class PatientDefinition extends StandardUserDefinition {
+  constructor(entityClient: ReturnType<typeof createDbClient>) {
+    super({
+      accountPropName: "email",
+      passwordPropName: "password",
+      entityClient,
+      ttl: 24 * 3600,
+    });
+  }
+
+  authorize() {
+    return Promise.resolve(true);
+  }
+}
+
+export const createHttpClient = (port: number): PhenylHttpClient<MyTypeMap> => {
+  return new PhenylHttpClient({
+    url: `${HTTP_CLIENT_URL}:${port}`,
+  });
+};
+
+export const createPhenylRedux = (client: PhenylHttpClient<MyTypeMap>) => {
+  const { reducer, middleware, actions } = createRedux({
+    client,
+    storeKey: "phenyl",
+  });
+  const store = createStore<Store, GeneralAction, {}, {}>(
+    combineReducers({ phenyl: reducer }),
+    applyMiddleware(middleware)
+  );
+  return { store, actions };
+};
+
+export const createDbClient = () => {
+  return createMemoryClient<ResponseEntityMapOf<MyTypeMap>>();
+};
+
+export const createSessionClient = (
+  entityClient: ReturnType<typeof createDbClient>
+) => {
+  return entityClient.createSessionClient<AuthCommandMapOf<MyTypeMap>>();
+};
+
+export const createServer = (dbClient: ReturnType<typeof createDbClient>) => {
+  const functionalGroup = {
+    customQueries: {},
+    customCommands: {},
+    users: {
+      patient: new PatientDefinition(dbClient),
+    },
+    nonUsers: {},
+  };
+
+  const restApiHandler: PhenylRestApi<MyTypeMap> = new PhenylRestApi<MyTypeMap>(
+    functionalGroup,
+    {
+      entityClient: dbClient,
+    }
+  );
+
+  return new PhenylHttpServer(http.createServer(), {
+    restApiHandler,
+  });
+};

--- a/modules/redux/test/spec/local-state-updater.test.ts
+++ b/modules/redux/test/spec/local-state-updater.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import assert from "assert";
-import { LocalStateUpdater } from "../src/local-state-updater";
-import { createInitialState } from "../src/reducer";
+import { LocalStateUpdater } from "../../src/local-state-updater";
+import { createInitialState } from "../../src/reducer";
 
 describe("LocalStateUpdater", () => {
   describe("addUnreachedCommits", () => {
@@ -9,7 +9,7 @@ describe("LocalStateUpdater", () => {
       const unreachedCommits = {
         id: "hoge",
         entityName: "foo",
-        commitCount: 1
+        commitCount: 1,
       };
       const state = createInitialState();
       assert.deepStrictEqual(
@@ -21,11 +21,11 @@ describe("LocalStateUpdater", () => {
       const unreachedCommits = {
         entityName: "foo",
         id: "hoge",
-        commitCount: 5
+        commitCount: 5,
       };
       const state = createInitialState();
       state.unreachedCommits = [
-        { entityName: "foo", id: "hoge", commitCount: 2 }
+        { entityName: "foo", id: "hoge", commitCount: 2 },
       ];
 
       assert.deepStrictEqual(
@@ -35,9 +35,9 @@ describe("LocalStateUpdater", () => {
             unreachedCommits: {
               entityName: "foo",
               id: "hoge",
-              commitCount: 3
-            }
-          }
+              commitCount: 3,
+            },
+          },
         }
       );
     });
@@ -45,12 +45,12 @@ describe("LocalStateUpdater", () => {
       const unreachedCommit = {
         entityName: "foo",
         id: "hoge",
-        commitCount: 3
+        commitCount: 3,
       };
       const state = createInitialState();
       state.unreachedCommits = [
         { entityName: "foo", id: "hoge", commitCount: 1 },
-        { entityName: "foo", id: "hoge", commitCount: 2 }
+        { entityName: "foo", id: "hoge", commitCount: 2 },
       ];
       const newState = Object.assign(
         state,
@@ -63,12 +63,12 @@ describe("LocalStateUpdater", () => {
       const unreachedCommit = {
         entityName: "foo",
         id: "hoge",
-        commitCount: 2
+        commitCount: 2,
       };
       const state = createInitialState();
       state.unreachedCommits = [
         { entityName: "foo", id: "hoge", commitCount: 1 },
-        { entityName: "foo", id: "hoge", commitCount: 2 }
+        { entityName: "foo", id: "hoge", commitCount: 2 },
       ];
       const newState = Object.assign(
         state,
@@ -83,7 +83,7 @@ describe("LocalStateUpdater", () => {
       const unreachedCommits = {
         id: "hoge",
         entityName: "foo",
-        commitCount: 1
+        commitCount: 1,
       };
       const initialState = createInitialState();
       const state = Object.assign(
@@ -104,11 +104,11 @@ describe("LocalStateUpdater", () => {
                 {
                   commitCount: 1,
                   entityName: "foo",
-                  id: "hoge"
-                }
-              ]
-            }
-          }
+                  id: "hoge",
+                },
+              ],
+            },
+          },
         }
       );
     });
@@ -120,10 +120,10 @@ describe("LocalStateUpdater", () => {
         type: "NetworkFailed",
         at: "local",
         message: "An error occured",
-        ok: 0
+        ok: 0,
       };
       assert.deepStrictEqual(LocalStateUpdater.resolveError(), {
-        $unset: { error: "" }
+        $unset: { error: "" },
       });
     });
   });

--- a/modules/redux/test/spec/middleware.test.ts
+++ b/modules/redux/test/spec/middleware.test.ts
@@ -1,0 +1,187 @@
+import { it, describe, before, after, beforeEach } from "mocha";
+import assert from "assert";
+import * as sinon from "sinon";
+
+import {
+  createHttpClient,
+  createPhenylRedux,
+  createSessionClient,
+  createServer,
+  createDbClient,
+  PORT,
+} from "../helper";
+import { MiddlewareHandler } from "../../src/middleware";
+
+const dbClient = createDbClient();
+const httpClient = createHttpClient(PORT);
+
+const { store, actions } = createPhenylRedux(httpClient);
+const sessionClient = createSessionClient(dbClient);
+const server = createServer(dbClient);
+
+describe("middlewareHandler", async () => {
+  const plainSession = {
+    entityName: "patient" as const,
+    expiredAt: "",
+    userId: "shinout@example.com",
+    externalId: "",
+    ttl: 12345,
+  };
+
+  const plainPatient = {
+    name: "Shin Suzuki",
+    email: "shinout@example.com",
+    password: "shin123",
+  };
+
+  const preSession = await sessionClient.create(plainSession);
+
+  const middlewareHandler = new MiddlewareHandler(
+    () => store.getState().phenyl,
+    httpClient,
+    store.dispatch
+  );
+
+  let insertedPatient: any;
+
+  before(async () => {
+    server.listen(PORT);
+    insertedPatient = await httpClient.insertAndGet(
+      {
+        entityName: "patient",
+        value: plainPatient,
+      },
+      preSession.id
+    );
+    store.dispatch(
+      actions.follow(
+        "patient",
+        insertedPatient.entity,
+        insertedPatient.versionId
+      )
+    );
+  });
+  after(() => {
+    server.close();
+  });
+  describe("unreachedCommits", () => {
+    beforeEach(() => {
+      store.dispatch(
+        actions.assign([
+          {
+            $set: {
+              unreachedCommits: [
+                {
+                  entityName: "patient" as const,
+                  id: insertedPatient.entity.id,
+                  commitCount: 2,
+                },
+                {
+                  entityName: "staff" as const,
+                  id: "",
+                  commitCount: 2,
+                },
+              ],
+            },
+          },
+        ])
+      );
+    });
+
+    describe("commitAndPush", () => {
+      it("clear unreached commits if commits are pushed successfully", async () => {
+        const operations = await middlewareHandler.commitAndPush({
+          type: "phenyl/commitAndPush",
+          payload: {
+            entityName: "patient",
+            id: insertedPatient.entity.id,
+            operation: {},
+          },
+          tag: "",
+        });
+
+        store.dispatch(operations);
+        const { unreachedCommits } = store.getState().phenyl;
+
+        assert.strictEqual(unreachedCommits.length, 1);
+        assert.strictEqual(
+          unreachedCommits.every(({ id }) => id !== insertedPatient.entity.id),
+          true
+        );
+      });
+      it("doesn't clear unreached commits if commits are not pushed", async () => {
+        const stub = sinon.stub(httpClient, "push");
+        stub.throws(() => ({
+          type: "NetworkFailed",
+        }));
+
+        const operations = await middlewareHandler.commitAndPush({
+          type: "phenyl/commitAndPush",
+          payload: {
+            entityName: "patient",
+            id: insertedPatient.entity.id,
+            operation: {},
+          },
+          tag: "",
+        });
+
+        store.dispatch(operations);
+        const { unreachedCommits } = store.getState().phenyl;
+
+        assert.strictEqual(
+          unreachedCommits.filter(({ id }) => id === insertedPatient.entity.id)
+            .length,
+          1
+        );
+        stub.restore();
+      });
+    });
+    describe("pushAndCommit", () => {
+      it("clear unreached commits if commits are pushed successfully", async () => {
+        const operations = await middlewareHandler.pushAndCommit({
+          type: "phenyl/pushAndCommit",
+          payload: {
+            entityName: "patient",
+            id: insertedPatient.entity.id,
+            operation: {},
+          },
+          tag: "",
+        });
+
+        store.dispatch(operations);
+        const { unreachedCommits } = store.getState().phenyl;
+
+        assert.strictEqual(unreachedCommits.length, 1);
+        assert(
+          unreachedCommits.every(({ id }) => id !== insertedPatient.entity.id)
+        );
+      });
+      it("doesn't clear unreached commits if commits are not pushed", async () => {
+        const stub = sinon.stub(httpClient, "push");
+        stub.throws(() => ({
+          type: "NetworkFailed",
+        }));
+
+        const operations = await middlewareHandler.pushAndCommit({
+          type: "phenyl/pushAndCommit",
+          payload: {
+            entityName: "patient",
+            id: insertedPatient.entity.id,
+            operation: {},
+          },
+          tag: "",
+        });
+
+        store.dispatch(operations);
+        const { unreachedCommits } = store.getState().phenyl;
+
+        assert.strictEqual(
+          unreachedCommits.filter(({ id }) => id === insertedPatient.entity.id)
+            .length,
+          1
+        );
+        stub.restore();
+      });
+    });
+  });
+});

--- a/modules/redux/test/spec/middleware.test.ts
+++ b/modules/redux/test/spec/middleware.test.ts
@@ -77,6 +77,16 @@ describe("middlewareHandler", async () => {
                   commitCount: 2,
                 },
                 {
+                  entityName: "patient" as const,
+                  id: insertedPatient.entity.id,
+                  commitCount: 1,
+                },
+                {
+                  entityName: "patient" as const,
+                  id: insertedPatient.entity.id,
+                  commitCount: 1,
+                },
+                {
                   entityName: "staff" as const,
                   id: "",
                   commitCount: 2,
@@ -131,7 +141,7 @@ describe("middlewareHandler", async () => {
         assert.strictEqual(
           unreachedCommits.filter(({ id }) => id === insertedPatient.entity.id)
             .length,
-          1
+          3
         );
         stub.restore();
       });
@@ -178,7 +188,7 @@ describe("middlewareHandler", async () => {
         assert.strictEqual(
           unreachedCommits.filter(({ id }) => id === insertedPatient.entity.id)
             .length,
-          1
+          3
         );
         stub.restore();
       });


### PR DESCRIPTION
fix #603 

## Overview
Clear unreached commits when commits are pushed successfully in `middlewareHandler.commitAndPush` and `middlewareHandler.pushAndCommit`

In `middlewareHandler.push`, not clear unreached commits because commits are pushed by the number specified in the action payload, and all unreached commits may not be pushed.

see e5d67ff for fix
see 46499be for test