### PR TITLE
feat: pass mongoClientOptions for connect

### DIFF
--- a/modules/mongodb/src/connection.ts
+++ b/modules/mongodb/src/connection.ts
@@ -1,4 +1,4 @@
-import { Collection, MongoClient } from "mongodb";
+import { Collection, MongoClient, MongoClientOptions } from "mongodb";
 
 export interface MongoDbConnection {
   close(): void;
@@ -7,11 +7,13 @@ export interface MongoDbConnection {
 
 export async function connect(
   url: string,
-  dbName: string
+  dbName: string,
+  mongoClientOptions?: MongoClientOptions
 ): Promise<MongoDbConnection> {
   const dbClient = new MongoClient(url, {
     useNewUrlParser: true,
     useUnifiedTopology: true,
+    ...mongoClientOptions,
   });
   await dbClient.connect();
   return new PhenylMongoDbConnection({ dbClient, dbName });

--- a/modules/mongodb/test/mongodb-client.test.ts
+++ b/modules/mongodb/test/mongodb-client.test.ts
@@ -168,4 +168,23 @@ describe("MongodbClient", () => {
       assert.deepStrictEqual(result.hobbies, ["play soccer"]);
     });
   });
+
+  describe("mongoClientOptions", () => {
+    it("should pass mongoClientOptions to mongo client at connect", async () => {
+      const _conn = await connect(url, dbName, {
+        connectTimeoutMS: 8000,
+        reconnectTries: 10,
+      });
+
+      // @ts-expect-error
+      expect(_conn.dbClient.s.options).toMatchObject({
+        // NOTE: useNewUrlParser to useUnifiedTopology check for backward compatibility
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+        connectTimeoutMS: 8000,
+        reconnectTries: 10,
+      });
+      _conn.close();
+    });
+  });
 });


### PR DESCRIPTION
fix #738

Added the options to pass to mongo client when connecting. The options can be passed to change the timeout MS, the number of retries, etc. This allows AWS Lambda timeouts to be consistent with connect timeouts.
