### PR TITLE
fix(redux): handle until correctly in push

### DIFF
--- a/modules/redux/src/middleware.ts
+++ b/modules/redux/src/middleware.ts
@@ -346,7 +346,7 @@ export class MiddlewareHandler<TM extends GeneralTypeMap> {
               operations: result.operations,
               versionId: result.versionId,
             },
-            commits
+            commitsToPush
           )
         );
       }


### PR DESCRIPTION
### Issue Overview

When using the `until` option with the `push` operation in `redux`, commits that were not pushed could unintentionally be deleted.

### Root Cause

This issue occurred because the `synchronize` process considered all commits, instead of restricting the scope to the commits filtered by the `until` option.

### Fix

The logic has been updated to ensure that only commits within the range specified by `until` are targeted. This prevents unintended deletion of unpushed commits.