### PR TITLE
chore: update lerna configuration to enable forced publishing

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,6 +6,9 @@
   "command": {
     "version": {
       "message": "[skip ci] chore(release): publish %s"
+    },
+    "publish": {
+      "forcePublish": true
     }
   },
   "npmClient": "yarn",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint": "turbo lint",
     "prepare": "yarn clean && yarn build",
     "publish": "lerna publish",
+    "publish:dry": "lerna publish --dry-run --no-push",
     "test": "turbo test",
     "type-check": "turbo type-check",
     "watch": "lerna run watch --parallel"


### PR DESCRIPTION
# Description

Added `forcePublish` configuration to Lerna's publish command.

> [!NOTE]
> When we published 4.2.0, we failed to publish packages which have no changes. Therefore, we need config to publish ALL packages under workspace.


## Changes

- Added `forcePublish: true` setting in `lerna.json` under the `command.publish` section
- This configuration ensures all packages will be published regardless of version changes

## Purpose

This change enables forced publishing of all packages in the monorepo, which is useful when:
- We need to ensure all packages are published consistently
- We want to republish packages even when there are no dependency changes
- We need to maintain synchronization across all packages in the repository

## Impact

- All packages will be published during the release process, regardless of version changes

## Test

When perform dry-run publish on this brunch, all packages including they have no change should be published updated version.

```
> yarn publish:dry
yarn run v1.22.22
$ lerna publish --dry-run --no-push
lerna-lite notice cli v1.17.0
lerna-lite info [dry-run] > git rev-parse
lerna-lite WARN Yarn's registry proxy is broken, replacing with public npm registry
lerna-lite WARN If you don't have an npm token, you should exit and run "npm login"
lerna-lite info [dry-run] > git rev-parse
lerna-lite info current project version 4.2.0
lerna-lite info [dry-run] > git rev-list --count --all --max-count=1
lerna-lite WARN force-publish all packages
lerna-lite info Assuming all packages changed
? Select a new version (currently 4.2.0) Patch (4.2.1)

Changes (18 packages):
 - @phenyl/api-explorer-client: 4.2.0 => 4.2.1
 - @phenyl/api-explorer: 4.2.0 => 4.2.1
 - @phenyl/central-state: 4.2.0 => 4.2.1
 - @phenyl/express: 4.2.0 => 4.2.1
 - @phenyl/http-client: 4.2.0 => 4.2.1
 - @phenyl/http-rules: 4.2.0 => 4.2.1
 - @phenyl/http-server: 4.2.0 => 4.2.1
 - @phenyl/interfaces: 4.1.0 => 4.2.1
 - @phenyl/lambda-adapter: 4.2.0 => 4.2.1
 - @phenyl/memory-db: 4.2.0 => 4.2.1
 - @phenyl/mongodb: 4.2.0 => 4.2.1
 - @phenyl/redux: 4.2.0 => 4.2.1
 - @phenyl/rest-api: 4.1.0 => 4.2.1
 - @phenyl/standards: 4.2.0 => 4.2.1
 - @phenyl/state: 4.2.0 => 4.2.1
 - @phenyl/utils: 4.1.0 => 4.2.1
 - @phenyl/websocket-client: 4.2.0 => 4.2.1
 - @phenyl/websocket-server: 4.2.0 => 4.2.1

? [dry-run] Are you sure you want to publish these packages?
```

Please review and let me know if any adjustments are needed.