### PR TITLE
fix(rest-api): fix typo in validation error message (mesage → message)

### DIFF
--- a/modules/rest-api/src/phenyl-rest-api.ts
+++ b/modules/rest-api/src/phenyl-rest-api.ts
@@ -108,7 +108,7 @@ export class PhenylRestApi<TM extends GeneralTypeMap = GeneralTypeMap>
         await executor.validate(normalizedReqData, session);
       } catch (validationError) {
         validationError.message = `Validation Failed. ${
-          validationError.mesage
+          validationError.message
         }`;
         return {
           type: "error",


### PR DESCRIPTION
## Summary
- Fix typo in `phenyl-rest-api.ts` validation error handler: `validationError.mesage` → `validationError.message`

Fixes #778

## Details
The typo caused all validation errors to display `"Validation Failed. undefined"` instead of the actual message (e.g., `"Validation Failed. accessToken and newPhoneNumber are required"`).

## Test plan
- [x] `yarn workspace @phenyl/rest-api test` — 39/39 passed (existing tests)
- [x] `yarn workspace @phenyl/rest-api lint` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)