### PR TITLE
fix(rest-api): validationError.mesage -> .message in validation handler

### DIFF
--- a/modules/rest-api/src/phenyl-rest-api.ts
+++ b/modules/rest-api/src/phenyl-rest-api.ts
@@ -108,7 +108,7 @@ export class PhenylRestApi<TM extends GeneralTypeMap = GeneralTypeMap>
         await executor.validate(normalizedReqData, session);
       } catch (validationError) {
         validationError.message = `Validation Failed. ${
-          validationError.mesage
+          validationError.message
         }`;
         return {
           type: "error",


### PR DESCRIPTION
Fixes #778.

Real bug: the validation handler was reading from `validationError.mesage` (typo, missing 's') instead of `.message`, so **every** validation error surfaced as `"Validation Failed. undefined"` instead of the actual cause. Reporter said they currently ship a `patch-package` workaround.

```diff
  validationError.message = `Validation Failed. ${
-   validationError.mesage
+   validationError.message
  }`;
```

Single-character fix in `modules/rest-api/src/phenyl-rest-api.ts`; the compiled `lib/phenyl-rest-api.js` will regenerate on the next build.