### PR TITLE
chore: pin GitHub Actions versions to commit SHAs

### DIFF
--- a/.claude/rules/github-actions-pinning.md
+++ b/.claude/rules/github-actions-pinning.md
@@ -1,0 +1,22 @@
+---
+description: GitHub Actions version pinning rule
+globs:
+  - ".github/workflows/**/*.yml"
+  - ".github/actions/**/*.yml"
+---
+
+# GitHub Actions version pinning rule
+
+## Basic rules
+
+- When referencing an action with `uses:`, pin it to a commit hash (e.g. `@11bd71901bbe5b1630ceea73d27597364c9af683 # v4`) instead of a tag annotation (e.g. `@v4`).
+- Always pin to a commit hash to mitigate supply chain attacks.
+- Keep the original version tag in a comment (e.g. `# v4`).
+- Local/composite actions (`uses: ./.github/actions/...`) are out of scope.
+
+## Procedure when adding or updating a version
+
+1. Get the release date (`published_at`) via `gh api repos/{owner}/{repo}/releases/tags/{tag}`.
+2. **Confirm at least 3 days have passed since the release** (releases newer than 3 days are not used, to allow a detection window for supply chain attacks).
+3. After confirming, get the SHA via `gh api repos/{owner}/{repo}/git/ref/tags/{tag}` and pin to it.
+4. If less than 3 days old, warn the user and use the previous version instead.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
         node-version: ['16']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
@@ -21,11 +21,11 @@ jobs:
           npm -v
           yarn --version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -43,9 +43,9 @@ jobs:
         node-version: ['16']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
@@ -58,7 +58,7 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -76,9 +76,9 @@ jobs:
         node-version: ['16']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
@@ -91,7 +91,7 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -106,3 +106,33 @@ jobs:
         image: mongo:7.0
         ports:
           - 27017:27017
+
+  # --- SHA pinning verification job (shell grep version) ---
+  # No external tools required. Detects tag-based references with grep.
+  verify-actions-pinned:
+    name: Verify GitHub Actions are SHA-pinned
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Check for unpinned actions
+        run: |
+          # Only target YAML `uses:` key lines (leading indent + optional '-' + uses: + space).
+          # Match from the start of the line to avoid false positives on quoted strings
+          # inside shell scripts ('uses:...').
+          # Local actions (./) and Docker actions (docker://) are excluded.
+          unpinned=$(
+            grep -rnE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]+' .github/ \
+            | grep -v 'uses:[[:space:]]*\./' \
+            | grep -v 'uses:[[:space:]]*docker://' \
+            | grep -E 'uses:.*@' \
+            | grep -vE 'uses:[[:space:]]*[^[:space:]]+@[0-9a-f]{40}([[:space:]]|$)' \
+            || true
+          )
+          if [ -n "$unpinned" ]; then
+            echo "::error::Found unpinned GitHub Actions:"
+            echo "$unpinned"
+            echo ""
+            echo "Please change them to commit-hash format (e.g. action@<sha> # v4)."
+            exit 1
+          fi
+          echo "All actions are SHA-pinned."


### PR DESCRIPTION
## What changed

- Replaced tag annotations (`@v4`) with commit SHAs (`@<sha> # <tag>`) for all GitHub Actions references
- Pinned versions to specific commits to mitigate supply chain attacks
- Bumped the major version of the affected actions to their latest releases
- Added a Claude Code rule (`.claude/rules/github-actions-pinning.md`) to prevent future tag-based references (with the 3-day rule)
- Added a `verify-actions-pinned` job (shell-grep based) to detect unpinned actions in CI
- Added the `github-actions` ecosystem to `dependabot.yml` (with a 3-day cooldown)

## Converted Actions

| Action | Before | After | SHA |
|--------|--------|-------|-----|
| `actions/checkout` | `@v4` | `@v6.0.2` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/setup-node` | `@v4` | `@v6.4.0` | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` |
| `actions/cache` | `@v4` | `@v5.0.5` | `27d5ce7f107fe9357f9df03efb73ab90386fccae` |

All target releases are at least 3 days old and signature-verified.

## Notes on breaking changes

- `actions/checkout v5+`, `actions/setup-node v5+`, `actions/cache v5`: action runtime moved to Node.js 24. The `ubuntu-latest` GitHub-hosted runner already meets this requirement, so no impact.
- `actions/setup-node v6`: automatic caching is now limited to npm. This workflow explicitly sets `cache: 'yarn'`, so no impact.

## References

- [tj-actions/changed-files compromise](https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/)
- [Trivy Action compromise](https://diary.shift-js.info/trivy-compromise/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)