### PR TITLE
fix(mongodb): relax errmsg assertion for document validation failure

### DIFF
--- a/modules/mongodb/test/merge-ops.test.ts
+++ b/modules/mongodb/test/merge-ops.test.ts
@@ -294,7 +294,10 @@ describe("Merge Operations", () => {
           })
           .catch((e) => e);
         assert.deepStrictEqual(error.name, "MongoServerError");
-        assert.deepStrictEqual(error.errmsg, "Document failed validation");
+        assert.ok(
+          /Document failed validation/.test(error.errmsg),
+          `expected errmsg to contain "Document failed validation", got: ${error.errmsg}`
+        );
 
         const rollbackedResult = await client
           .db(dbName)


### PR DESCRIPTION
## Summary
- Fix continuous CI failure in `modules/mongodb/test/merge-ops.test.ts` when running against `mongo:latest`
- Relax the `errmsg` assertion for document validation failures from exact match to substring match, so the test is resilient to MongoDB version differences

## Background
The CI job `test (16)` (`@phenyl/mongodb#test`) has been failing on the following test:

```
Merge Operations › update operation › mongodb document validation
  › should rollback successfully when push failed with document validation
```

Expected vs. actual:
- Expected: `"Document failed validation"`
- Actual: `"Plan executor error during update :: caused by :: Document failed validation"`

Recent MongoDB versions (used by CI via `mongo:latest`) prepend `"Plan executor error during {op} :: caused by :: "` to the `errmsg` of a Document Validation Failure, which broke the previous exact-match assertion.

Note that the `errmsg` assertion at L178-182 in the same file (`Updating the path 'X' would create a conflict at 'X'`) is unaffected because it goes through the conflict error path, which does not get the new prefix.

## Changes
- Replace `assert.deepStrictEqual(error.errmsg, "Document failed validation")` with `assert.ok(/Document failed validation/.test(error.errmsg), ...)`
- Include the actual `errmsg` in the failure hint to make future regressions easier to diagnose

## Test plan
- [x] `yarn workspace @phenyl/mongodb type-check` → pass
- [x] `npx prettier --check modules/mongodb/test/merge-ops.test.ts` → pass
- [x] `CI=true yarn workspace @phenyl/mongodb test` against a local `mongo:latest` container → **18/18 tests pass (4 suites)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)