### PR TITLE
chore(ci): pin mongo service image to 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,6 @@ jobs:
       - run: yarn test
     services:
       mongodb:
-        image: mongo:latest
+        image: mongo:7.0
         ports:
           - 27017:27017


### PR DESCRIPTION
## Summary
- Pin the MongoDB service image in CI from `mongo:latest` to `mongo:7.0`
- Restores CI reproducibility and resolves the recent test failure caused by an upstream MongoDB error-message format change

## Background
The CI job `test (16)` (`@phenyl/mongodb#test`) has been failing on:

```
Merge Operations › update operation › mongodb document validation
  › should rollback successfully when push failed with document validation
```

The `errmsg` for a Document Validation Failure is now wrapped with the prefix `"Plan executor error during update :: caused by :: "` in the newest MongoDB releases pulled by `mongo:latest`. This broke the existing exact-match assertion in `modules/mongodb/test/merge-ops.test.ts:297`.

Using a floating `:latest` tag means any future MongoDB release can break CI without any change in this repository.

## Changes
- `.github/workflows/ci.yml`: `image: mongo:latest` → `image: mongo:7.0`

## Why mongo:7.0
- The `mongodb` Node driver used by `@phenyl/mongodb` is `^4.0.0`, whose supported MongoDB server range is up to 7.x
- `mongo:7.0` is the newest version that keeps the existing test assertions intact
- Locally verified that `mongo:6.0` and `mongo:7.0` both pass, while `mongo:8.x` (currently behind `:latest`) fails

## Test plan
- [x] Reproduce CI failure locally with `mongo:latest` (8.x) and the unchanged test file
- [x] `CI=true yarn workspace @phenyl/mongodb test` against `mongo:7.0` → **18/18 tests pass (4 suites)**
- [x] `CI=true yarn workspace @phenyl/mongodb test` against `mongo:6.0` → 18/18 pass (also verified for safety)

🤖 Generated with [Claude Code](https://claude.com/claude-code)