### PR TITLE
ci: add publish workflow using npm OIDC trusted publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,12 +27,12 @@ jobs:
       NPM_CONFIG_PROVENANCE: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Run publish in dry-run mode'
+        type: boolean
+        default: false
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      NPM_CONFIG_PROVENANCE: true
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+
+      - name: Display tool versions
+        run: |
+          node -v
+          npm -v
+          yarn --version
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build packages
+        run: yarn build
+
+      - name: Publish to npm (dry-run)
+        if: ${{ inputs.dry-run }}
+        run: yarn lerna publish from-package --yes --dry-run
+
+      - name: Publish to npm
+        if: ${{ !inputs.dry-run }}
+        run: yarn lerna publish from-package --yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,11 +75,27 @@ This command generates `lib/**/*.js` and `lib/**/*.d.ts` from `src/**/*.ts`.
 
 ## Release
 
-**Must be a member of the npm organization's `phenyl-release-members` team.**
+Releases are published to npm via GitHub Actions using [npm Trusted Publishers (OIDC)](https://docs.npmjs.com/trusted-publishers), so no `NPM_TOKEN` is required.
 
-```
-npm whoami # Print your npm account that has already joined organization
-git checkout master
-yarn build
-yarn run publish
-```
+### Prerequisites (one-time setup per package)
+Each `@phenyl/*` package on npmjs.com must have a Trusted Publisher entry pointing to:
+- Repository: `phenyl-js/phenyl`
+- Workflow: `.github/workflows/publish.yml`
+- Environment: _(none)_
+
+### Cutting a release
+1. From `master`, bump versions and create a git tag locally:
+   ```bash
+   git checkout master
+   yarn build
+   yarn lerna version            # bumps versions, creates tag `vX.Y.Z`, pushes commits
+   ```
+2. Push the tag to GitHub:
+   ```bash
+   git push origin vX.Y.Z
+   ```
+3. The `Publish` workflow runs automatically on the tag push and publishes every package
+   whose `version` is not yet on the registry (`lerna publish from-package`) with provenance.
+
+You can also trigger the workflow manually from the Actions tab; tick `dry-run` to validate
+the pipeline without publishing.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` — a GitHub Actions workflow that publishes the `@phenyl/*` packages to npm via [npm Trusted Publishers (OIDC)](https://docs.npmjs.com/trusted-publishers), with build provenance enabled. No long-lived `NPM_TOKEN` is required.
- The workflow triggers on `v*` tag pushes and via `workflow_dispatch` (with an optional `dry-run` input).
- Uses `yarn lerna publish from-package --yes`, so versioning still happens locally with `yarn lerna version`; the workflow only publishes packages whose `version` is not yet on the registry.
- Updates the `Release` section of `CONTRIBUTING.md` to describe the new flow and the required npmjs.com setup.

## Required setup on npmjs.com (one-time, per package)
Each `@phenyl/*` package needs a Trusted Publisher entry pointing to:
- Repository: `phenyl/phenyl`
- Workflow file: `.github/workflows/publish.yml`
- Environment: _(none)_

Until those entries exist, the `Publish to npm` step will fail with an OIDC authentication error — this is expected and the dry-run mode can be used to validate the rest of the pipeline beforehand.

## Notes / design choices
- `permissions: id-token: write` is required for OIDC; `contents: read` is the minimum for `actions/checkout`.
- Node.js `24` is used because OIDC trusted publishing requires npm `>=11.5.1`. This only affects the publish job; CI workflows are untouched.
- `NPM_CONFIG_PROVENANCE=true` is set as a job-level env so every nested `npm publish` call performed by `lerna publish` emits a provenance attestation, with no per-package configuration needed.
- `concurrency` is keyed on the ref to prevent overlapping publishes for the same tag, but `cancel-in-progress: false` so an in-flight publish is never aborted mid-flight.
- `lerna publish from-package` (rather than the default version-bump-and-publish flow) decouples versioning from CI: a release author still runs `yarn lerna version` locally and pushes the resulting tag, which is what fires the workflow.

## Test plan
- [x] Register Trusted Publisher entries on npmjs.com for each `@phenyl/*` package.
- [ ] Trigger the workflow manually from the Actions tab with `dry-run: true` and confirm OIDC auth + `lerna publish --dry-run` succeed.
- [ ] On the next release, push a `vX.Y.Z` tag and confirm packages are published with provenance attestations visible on npmjs.com.