### PR TITLE
fix(utils)!: correct runCustomCommand result extra-result type

### DIFF
--- a/modules/utils/src/phenyl-rest-api-client.ts
+++ b/modules/utils/src/phenyl-rest-api-client.ts
@@ -53,7 +53,8 @@ import {
   CustomQueryExtraParamsOf,
   CustomCommandExtraParamsOf,
   EntityExtraResultOf,
-  CustomQueryExtraResultOf
+  CustomQueryExtraResultOf,
+  CustomCommandExtraResultOf
 } from "@phenyl/interfaces";
 
 import { createServerError } from "./create-error";
@@ -430,7 +431,7 @@ export abstract class PhenylRestApiClient<
   ): Promise<
     CustomCommandResult<
       CustomCommandResultValueOf<TM, CN>,
-      CustomQueryExtraResultOf<TM, CN>
+      CustomCommandExtraResultOf<TM, CN>
     >
   > {
     const resData = await this.handleRequestData({


### PR DESCRIPTION
## Summary

`PhenylRestApiClient.runCustomCommand` declared its result's extra-result type via `CustomQueryExtraResultOf`, so the `extra` field was typed against the **custom-query** map (keyed by the command name, which resolves to the default `ExtraResult`) instead of the **custom command**'s own extra result. This switches it to `CustomCommandExtraResultOf` so the type matches the command.

Runtime behaviour is unchanged — this only corrects the published types.

## Changes

- `modules/utils/src/phenyl-rest-api-client.ts`: `runCustomCommand` return type `CustomQueryExtraResultOf<TM, CN>` → `CustomCommandExtraResultOf<TM, CN>` (+ import).

## Breaking change

`BREAKING CHANGE:` the return type of `runCustomCommand` now reflects the custom command's extra result. Code that relied on the previous (incorrect) type may need updating.

## Notes

Split out of the toolchain PR #785 — it's a separate, type-level breaking change and is clearer to review and release on its own.